### PR TITLE
Set `CMAKE_CXX_STANDARD ` in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 project(weather)
 
+set(CMAKE_CXX_STANDARD 17)
+
 find_package(CURL REQUIRED)
 
 add_executable(weather weather.cpp)


### PR DESCRIPTION
This PR adds `CMAKE_CXX_STANDARD` setting to avoid build errors.

Without this setting I'm not able to build the application.

My setup:
```
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: arm64-apple-darwin22.5.0
Thread model: posix
```